### PR TITLE
Fix work date bug

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,6 @@ name: Stephen McCullough
 twitter: https://twitter.com/swmcc
 linkedin: https://uk.linkedin.com/in/theonlystephen
 github: https://github.com/swmcc
-email: me@theonlystephen.com
+email: stephen@skillfulgorilla.com 
 
 exclude: ["start_development", ".rvmrc", ".rbenv-version", ".gitignore", "README.md", "Rakefile", "changelog.md", "Gemfile", "Gemfile.lock", "Procfile", "vendor"]

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -27,9 +27,14 @@ selected: blog
           <a href="https://twitter.com/share" class="twitter-share-button" data-via="swmcc" data-size="large" data-count="none">Share on Twitter</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
         </div>
+        {% if page.type == "post" %}
          <p class="published meta">Published on {{ page.date | date_to_string }} </p>
          <hr />
          <a href="{{ site.baseurl }}/blog/" class="read-more">Back to all posts</a>
+        {% else %}
+         <hr />
+         <a href="{{ site.baseurl }}/work/" class="read-more">Back to all work articles</a>
+        {% endif %}
       </article>
     </section>
     <section class="recent-posts-section">

--- a/_posts/1970-01-01-bushmills.html
+++ b/_posts/1970-01-01-bushmills.html
@@ -1,5 +1,5 @@
 ---
-type: post
+type: work
 tags: work, github, streak, day50, development
 tech: gulp, jekyll, ruby, javascript 
 published: true

--- a/_posts/1970-01-01-haig.html
+++ b/_posts/1970-01-01-haig.html
@@ -1,5 +1,5 @@
 ---
-type: post
+type: work 
 tags: work, github, streak, day50, development
 tech: django, postgres 
 published: true

--- a/_posts/1970-01-01-nestoria.tv.html
+++ b/_posts/1970-01-01-nestoria.tv.html
@@ -1,5 +1,5 @@
 ---
-type: post
+type: work 
 tags: work, github, streak, day50, development
 tech: django api 
 published: true

--- a/_posts/1970-01-01-roadclient.html
+++ b/_posts/1970-01-01-roadclient.html
@@ -1,5 +1,5 @@
 ---
-type: post
+type: work 
 tags: work, github, streak, day50, development
 tech: ruby, rails, angular, postgres 
 published: true

--- a/_posts/1970-01-01-skillful.html
+++ b/_posts/1970-01-01-skillful.html
@@ -1,5 +1,5 @@
 ---
-type: post
+type: work 
 tags: work, github, streak, day50, development
 tech: gulp, jekyll, ruby, javascript 
 published: true

--- a/_posts/1970-01-01-theonlystephen.html
+++ b/_posts/1970-01-01-theonlystephen.html
@@ -1,5 +1,5 @@
 ---
-type: post
+type: work 
 tags: work, github, streak, day50, development
 tech: gulp, jekyll, ruby, javascript 
 published: true

--- a/_posts/1970-01-01-utv.html
+++ b/_posts/1970-01-01-utv.html
@@ -1,5 +1,5 @@
 ---
-type: post
+type: work
 tags: work, github, streak, day50, development
 tech: gulp, jekyll, ruby, javascript 
 published: true


### PR DESCRIPTION
Fixed a bug where an work article was displaying the date. As work articles are essentially blog posts but have no date they start with ```1970-01-01-title.html``` the date was being rendered out

![screen shot 2016-09-26 at 11 54 37](https://cloud.githubusercontent.com/assets/356955/18831872/05e0943e-83e0-11e6-87ac-8e7fbb69c2bc.png)
