### PR TITLE
Add a link to the recently added feed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,6 +6,7 @@
 
 <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
 <meta name="description" content="={{ site.description }}">
+{% feed_meta %}
 
 <link rel="shortcut icon" href="{{ '/favicon.ico' | prepend: site.baseurl }}" type="image/x-icon">
 <link rel="icon" href="{{ '/favicon.ico' | prepend: site.baseurl }}" type="image/x-icon">


### PR DESCRIPTION
Add a link in the header of the site to the new feed. `feed_meta` is mentioned in the [jekyll-feed docs](https://github.com/jekyll/jekyll-feed#meta-tags).