### PR TITLE
Add dev.to syndication workflow

### DIFF
--- a/.github/workflows/syndicate.yml
+++ b/.github/workflows/syndicate.yml
@@ -1,0 +1,41 @@
+name: Syndicate to dev.to
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/content/writing/**'
+      - 'src/content/notes/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  syndicate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run syndication
+        run: node scripts/syndicate.mjs
+        env:
+          DEVTO_API_KEY: ${{ secrets.DEVTO_API_KEY }}
+
+      - name: Commit devtoId updates
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add src/content/writing/*.md src/content/notes/*.md || true
+          git diff --staged --quiet || git commit -m "🔄 Update devtoId from syndication"
+          git push || true

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ local.clean:
 local.hero:
 	node scripts/fetch-hero-images.mjs
 
+local.syndicate:
+	node scripts/syndicate.mjs
+
 content.writing:
 	@read -p "Enter slug (e.g., my-new-post): " slug; \
 	read -p "Enter title: " title; \

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "test": "playwright test",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "syndicate": "node scripts/syndicate.mjs"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.9",

--- a/scripts/syndicate.mjs
+++ b/scripts/syndicate.mjs
@@ -33,6 +33,13 @@ if (!DEVTO_API_KEY) {
   process.exit(0);
 }
 
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+function sanitizeTag(tag) {
+  // dev.to only allows alphanumeric characters
+  return tag.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
 function parseFrontmatter(content) {
   const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
   if (!match) {
@@ -118,7 +125,7 @@ async function processFile(filepath, urlPath) {
 
   const slug = path.basename(filepath, '.md');
   const canonicalUrl = `${SITE_URL}/${urlPath}/${slug}`;
-  const tags = (frontmatter.tags || []).slice(0, 4);
+  const tags = (frontmatter.tags || []).slice(0, 4).map(sanitizeTag).filter(Boolean);
 
   const article = {
     title: frontmatter.title,
@@ -189,10 +196,14 @@ async function main() {
         if (result) {
           if (result.action === 'created') created++;
           if (result.action === 'updated') updated++;
+          // Rate limit: wait 10 seconds between API calls
+          await sleep(10000);
         }
       } catch (err) {
         console.error(`  Error processing ${file}: ${err.message}`);
         errors++;
+        // Wait 35 seconds after rate limit error
+        await sleep(35000);
       }
     }
 

--- a/scripts/syndicate.mjs
+++ b/scripts/syndicate.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+
+/**
+ * Syndicates content to dev.to via their API.
+ * Posts with `syndicate: true` in frontmatter will be published.
+ * The dev.to article ID is stored back in the frontmatter as `devtoId`.
+ *
+ * Run: DEVTO_API_KEY=xxx node scripts/syndicate.mjs
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { config } from 'dotenv';
+import yaml from 'js-yaml';
+
+config();
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+const DEVTO_API_KEY = process.env.DEVTO_API_KEY?.trim();
+const DEVTO_API_URL = 'https://dev.to/api/articles';
+const SITE_URL = 'https://swm.cc';
+
+const COLLECTIONS = [
+  { name: 'writing', dir: path.join(PROJECT_ROOT, 'src/content/writing'), urlPath: 'writing' },
+  { name: 'notes', dir: path.join(PROJECT_ROOT, 'src/content/notes'), urlPath: 'notes' },
+];
+
+if (!DEVTO_API_KEY) {
+  console.log('DEVTO_API_KEY not set, skipping syndication');
+  process.exit(0);
+}
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) {
+    return { frontmatter: {}, body: content };
+  }
+  const frontmatter = yaml.load(match[1]);
+  const body = match[2].trim();
+  return { frontmatter, body };
+}
+
+function serializeFrontmatter(frontmatter, body) {
+  const yamlStr = yaml.dump(frontmatter, {
+    quotingType: '"',
+    forceQuotes: false,
+    lineWidth: -1,
+  }).trim();
+  return `---\n${yamlStr}\n---\n\n${body}\n`;
+}
+
+async function getDevtoArticle(id) {
+  const response = await fetch(`${DEVTO_API_URL}/${id}`, {
+    headers: {
+      'api-key': DEVTO_API_KEY,
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 404) return null;
+    throw new Error(`Failed to fetch article ${id}: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+async function createDevtoArticle(article) {
+  const response = await fetch(DEVTO_API_URL, {
+    method: 'POST',
+    headers: {
+      'api-key': DEVTO_API_KEY,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ article }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to create article: ${response.status} - ${text}`);
+  }
+
+  return response.json();
+}
+
+async function updateDevtoArticle(id, article) {
+  const response = await fetch(`${DEVTO_API_URL}/${id}`, {
+    method: 'PUT',
+    headers: {
+      'api-key': DEVTO_API_KEY,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ article }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to update article ${id}: ${response.status} - ${text}`);
+  }
+
+  return response.json();
+}
+
+async function processFile(filepath, urlPath) {
+  const content = await fs.readFile(filepath, 'utf-8');
+  const { frontmatter, body } = parseFrontmatter(content);
+
+  if (!frontmatter.syndicate) {
+    return null;
+  }
+
+  if (frontmatter.draft) {
+    console.log(`  Skipping draft: ${frontmatter.title}`);
+    return null;
+  }
+
+  const slug = path.basename(filepath, '.md');
+  const canonicalUrl = `${SITE_URL}/${urlPath}/${slug}`;
+  const tags = (frontmatter.tags || []).slice(0, 4);
+
+  const article = {
+    title: frontmatter.title,
+    body_markdown: body,
+    canonical_url: canonicalUrl,
+    published: true,
+    tags,
+  };
+
+  if (frontmatter.description) {
+    article.description = frontmatter.description;
+  }
+
+  let result;
+  let action;
+
+  if (frontmatter.devtoId) {
+    const existing = await getDevtoArticle(frontmatter.devtoId);
+    if (existing) {
+      console.log(`  Updating: ${frontmatter.title}`);
+      result = await updateDevtoArticle(frontmatter.devtoId, article);
+      action = 'updated';
+    } else {
+      console.log(`  Article ${frontmatter.devtoId} not found, creating new: ${frontmatter.title}`);
+      result = await createDevtoArticle(article);
+      action = 'created';
+    }
+  } else {
+    console.log(`  Creating: ${frontmatter.title}`);
+    result = await createDevtoArticle(article);
+    action = 'created';
+  }
+
+  if (action === 'created' && result.id !== frontmatter.devtoId) {
+    frontmatter.devtoId = result.id;
+    const newContent = serializeFrontmatter(frontmatter, body);
+    await fs.writeFile(filepath, newContent);
+    console.log(`    Saved devtoId: ${result.id}`);
+  }
+
+  return { action, id: result.id, url: result.url };
+}
+
+async function main() {
+  console.log('Starting dev.to syndication...\n');
+
+  let created = 0;
+  let updated = 0;
+  let errors = 0;
+
+  for (const collection of COLLECTIONS) {
+    console.log(`Processing ${collection.name}/`);
+
+    let files;
+    try {
+      files = await fs.readdir(collection.dir);
+    } catch {
+      console.log(`  Directory not found, skipping\n`);
+      continue;
+    }
+
+    const mdFiles = files.filter(f => f.endsWith('.md'));
+
+    for (const file of mdFiles) {
+      const filepath = path.join(collection.dir, file);
+      try {
+        const result = await processFile(filepath, collection.urlPath);
+        if (result) {
+          if (result.action === 'created') created++;
+          if (result.action === 'updated') updated++;
+        }
+      } catch (err) {
+        console.error(`  Error processing ${file}: ${err.message}`);
+        errors++;
+      }
+    }
+
+    console.log('');
+  }
+
+  console.log('Syndication complete:');
+  console.log(`  Created: ${created}`);
+  console.log(`  Updated: ${updated}`);
+  console.log(`  Errors: ${errors}`);
+
+  if (errors > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,7 +8,9 @@ const writing = defineCollection({
     pubDate: z.coerce.date(),
     updatedDate: z.coerce.date().optional(),
     tags: z.array(z.string()).optional(),
-    draft: z.boolean().optional()
+    draft: z.boolean().optional(),
+    syndicate: z.boolean().optional(),
+    devtoId: z.number().optional()
   })
 });
 
@@ -17,7 +19,9 @@ const notes = defineCollection({
   schema: z.object({
     title: z.string(),
     pubDate: z.coerce.date(),
-    tags: z.array(z.string()).optional()
+    tags: z.array(z.string()).optional(),
+    syndicate: z.boolean().optional(),
+    devtoId: z.number().optional()
   })
 });
 

--- a/src/content/notes/custom-agents-for-claude-code.md
+++ b/src/content/notes/custom-agents-for-claude-code.md
@@ -1,8 +1,12 @@
 ---
-title: "Custom Agents for Claude Code"
-pubDate: 2026-02-19
-tags: ["claude-code", "automation", "ai"]
+title: Custom Agents for Claude Code
+pubDate: 2026-02-19T00:00:00.000Z
+tags:
+  - claude-code
+  - automation
+  - ai
 syndicate: true
+devtoId: 3442459
 ---
 
 Claude Code ships with a general-purpose agent, but it doesn't know your stack, your conventions, or your workflows. Custom agents fix that.

--- a/src/content/notes/custom-agents-for-claude-code.md
+++ b/src/content/notes/custom-agents-for-claude-code.md
@@ -2,6 +2,7 @@
 title: "Custom Agents for Claude Code"
 pubDate: 2026-02-19
 tags: ["claude-code", "automation", "ai"]
+syndicate: true
 ---
 
 Claude Code ships with a general-purpose agent, but it doesn't know your stack, your conventions, or your workflows. Custom agents fix that.

--- a/src/content/notes/cypress-component-isolation-problem.md
+++ b/src/content/notes/cypress-component-isolation-problem.md
@@ -2,6 +2,7 @@
 title: "Cypress Component Isolation Issues"
 pubDate: 2025-11-06
 tags: ["cypress", "testing", "playwright", "e2e"]
+syndicate: true
 ---
 
 Working on a personal project, I hit a frustrating limitation with Cypress: component state bleeding between tests.

--- a/src/content/notes/cypress-component-isolation-problem.md
+++ b/src/content/notes/cypress-component-isolation-problem.md
@@ -1,8 +1,13 @@
 ---
-title: "Cypress Component Isolation Issues"
-pubDate: 2025-11-06
-tags: ["cypress", "testing", "playwright", "e2e"]
+title: Cypress Component Isolation Issues
+pubDate: 2025-11-06T00:00:00.000Z
+tags:
+  - cypress
+  - testing
+  - playwright
+  - e2e
 syndicate: true
+devtoId: 3442466
 ---
 
 Working on a personal project, I hit a frustrating limitation with Cypress: component state bleeding between tests.

--- a/src/content/notes/dropping-down-to-raw-asgi.md
+++ b/src/content/notes/dropping-down-to-raw-asgi.md
@@ -1,8 +1,12 @@
 ---
-title: "Dropping Down to Raw ASGI"
-pubDate: 2026-03-18
-tags: ["python", "asgi", "fastapi"]
+title: Dropping Down to Raw ASGI
+pubDate: 2026-03-18T00:00:00.000Z
+tags:
+  - python
+  - asgi
+  - fastapi
 syndicate: true
+devtoId: 3442460
 ---
 
 Building [mailview](https://github.com/swmcc/mailview), `Mount` looked like the obvious choice for attaching routes at `/_mail`. It wasn't.

--- a/src/content/notes/dropping-down-to-raw-asgi.md
+++ b/src/content/notes/dropping-down-to-raw-asgi.md
@@ -2,6 +2,7 @@
 title: "Dropping Down to Raw ASGI"
 pubDate: 2026-03-18
 tags: ["python", "asgi", "fastapi"]
+syndicate: true
 ---
 
 Building [mailview](https://github.com/swmcc/mailview), `Mount` looked like the obvious choice for attaching routes at `/_mail`. It wasn't.

--- a/src/content/notes/git-worktree-trick.md
+++ b/src/content/notes/git-worktree-trick.md
@@ -2,6 +2,7 @@
 title: "Git Worktree for Multiple Branches"
 pubDate: 2025-10-28
 tags: ["git", "productivity"]
+syndicate: true
 ---
 
 Just learned about `git worktree` and it's genuinely useful.

--- a/src/content/notes/git-worktree-trick.md
+++ b/src/content/notes/git-worktree-trick.md
@@ -1,8 +1,11 @@
 ---
-title: "Git Worktree for Multiple Branches"
-pubDate: 2025-10-28
-tags: ["git", "productivity"]
+title: Git Worktree for Multiple Branches
+pubDate: 2025-10-28T00:00:00.000Z
+tags:
+  - git
+  - productivity
 syndicate: true
+devtoId: 3442468
 ---
 
 Just learned about `git worktree` and it's genuinely useful.

--- a/src/content/notes/lazy-loading-cache-pattern.md
+++ b/src/content/notes/lazy-loading-cache-pattern.md
@@ -1,8 +1,12 @@
 ---
-title: "Lazy Loading Cache for whatisonthe.tv"
-pubDate: 2025-11-16
-tags: ["caching", "architecture", "python"]
+title: Lazy Loading Cache for whatisonthe.tv
+pubDate: 2025-11-16T00:00:00.000Z
+tags:
+  - caching
+  - architecture
+  - python
 syndicate: true
+devtoId: 3442469
 ---
 
 Working on [whatisonthe.tv](https://whatisonthe.tv), I needed a caching pattern for film and star metadata lookups. The app pulls data from external APIs (TMDb for cast lists, film details) but only when the data doesn't exist in the database. A background worker fetches from the API and saves it to the database, avoiding repeated expensive API calls. The cache sits in front of the database to speed up reads.

--- a/src/content/notes/lazy-loading-cache-pattern.md
+++ b/src/content/notes/lazy-loading-cache-pattern.md
@@ -2,6 +2,7 @@
 title: "Lazy Loading Cache for whatisonthe.tv"
 pubDate: 2025-11-16
 tags: ["caching", "architecture", "python"]
+syndicate: true
 ---
 
 Working on [whatisonthe.tv](https://whatisonthe.tv), I needed a caching pattern for film and star metadata lookups. The app pulls data from external APIs (TMDb for cast lists, film details) but only when the data doesn't exist in the database. A background worker fetches from the API and saves it to the database, avoiding repeated expensive API calls. The cache sits in front of the database to speed up reads.

--- a/src/content/notes/self-hosted-image-sharing-pipeline.md
+++ b/src/content/notes/self-hosted-image-sharing-pipeline.md
@@ -2,6 +2,7 @@
 title: "A Self-Hosted Image Sharing Pipeline"
 pubDate: 2026-01-30
 tags: ["rails", "ruby", "automation", "macos"]
+syndicate: true
 ---
 
 Image URLs break. You paste a screenshot into Teams, share the link, and six months later it's gone. Corporate firewalls block Imgur. Third-party services sunset features. The URLs you thought were permanent quietly rot.

--- a/src/content/notes/self-hosted-image-sharing-pipeline.md
+++ b/src/content/notes/self-hosted-image-sharing-pipeline.md
@@ -1,8 +1,13 @@
 ---
-title: "A Self-Hosted Image Sharing Pipeline"
-pubDate: 2026-01-30
-tags: ["rails", "ruby", "automation", "macos"]
+title: A Self-Hosted Image Sharing Pipeline
+pubDate: 2026-01-30T00:00:00.000Z
+tags:
+  - rails
+  - ruby
+  - automation
+  - macos
 syndicate: true
+devtoId: 3442477
 ---
 
 Image URLs break. You paste a screenshot into Teams, share the link, and six months later it's gone. Corporate firewalls block Imgur. Third-party services sunset features. The URLs you thought were permanent quietly rot.

--- a/src/content/notes/the-llm-is-the-new-parser.md
+++ b/src/content/notes/the-llm-is-the-new-parser.md
@@ -1,8 +1,13 @@
 ---
-title: "The LLM Is the New Parser"
-pubDate: 2026-02-24
-tags: ["llm", "ollama", "parsing", "ai"]
+title: The LLM Is the New Parser
+pubDate: 2026-02-24T00:00:00.000Z
+tags:
+  - llm
+  - ollama
+  - parsing
+  - ai
 syndicate: true
+devtoId: 3442470
 ---
 
 I spent the early 2000s writing parsers. HTML scrapers with regex that would make you cry. XML deserializers that handled seventeen flavours of "valid". CSV readers that knew a comma inside quotes wasn't a delimiter.

--- a/src/content/notes/the-llm-is-the-new-parser.md
+++ b/src/content/notes/the-llm-is-the-new-parser.md
@@ -2,6 +2,7 @@
 title: "The LLM Is the New Parser"
 pubDate: 2026-02-24
 tags: ["llm", "ollama", "parsing", "ai"]
+syndicate: true
 ---
 
 I spent the early 2000s writing parsers. HTML scrapers with regex that would make you cry. XML deserializers that handled seventeen flavours of "valid". CSV readers that knew a comma inside quotes wasn't a delimiter.

--- a/src/content/notes/typescript-conditional-types.md
+++ b/src/content/notes/typescript-conditional-types.md
@@ -1,8 +1,11 @@
 ---
-title: "TypeScript Conditional Types for API Responses"
-pubDate: 2025-11-03
-tags: ["typescript", "types"]
+title: TypeScript Conditional Types for API Responses
+pubDate: 2025-11-03T00:00:00.000Z
+tags:
+  - typescript
+  - types
 syndicate: true
+devtoId: 3442462
 ---
 
 Quick pattern I keep using for API responses that can be either successful or error states:

--- a/src/content/notes/typescript-conditional-types.md
+++ b/src/content/notes/typescript-conditional-types.md
@@ -2,6 +2,7 @@
 title: "TypeScript Conditional Types for API Responses"
 pubDate: 2025-11-03
 tags: ["typescript", "types"]
+syndicate: true
 ---
 
 Quick pattern I keep using for API responses that can be either successful or error states:

--- a/src/content/writing/adding-oauth-to-the-auth-service.md
+++ b/src/content/writing/adding-oauth-to-the-auth-service.md
@@ -1,9 +1,15 @@
 ---
-title: "Adding OAuth to the Authentication Service"
-description: "Extending the authentication microservice with OAuth 2.0 support for Keycloak and Google, evaluating FastAPI libraries, and why I chose aioauth"
-pubDate: 2025-12-02
-tags: ["authentication", "oauth", "microservices", "fastapi", "keycloak"]
+title: Adding OAuth to the Authentication Service
+description: Extending the authentication microservice with OAuth 2.0 support for Keycloak and Google, evaluating FastAPI libraries, and why I chose aioauth
+pubDate: 2025-12-02T00:00:00.000Z
+tags:
+  - authentication
+  - oauth
+  - microservices
+  - fastapi
+  - keycloak
 syndicate: true
+devtoId: 3442455
 ---
 
 ## The Next Step

--- a/src/content/writing/adding-oauth-to-the-auth-service.md
+++ b/src/content/writing/adding-oauth-to-the-auth-service.md
@@ -3,6 +3,7 @@ title: "Adding OAuth to the Authentication Service"
 description: "Extending the authentication microservice with OAuth 2.0 support for Keycloak and Google, evaluating FastAPI libraries, and why I chose aioauth"
 pubDate: 2025-12-02
 tags: ["authentication", "oauth", "microservices", "fastapi", "keycloak"]
+syndicate: true
 ---
 
 ## The Next Step

--- a/src/content/writing/automating-activity-feeds.md
+++ b/src/content/writing/automating-activity-feeds.md
@@ -1,9 +1,13 @@
 ---
-title: "Automating Activity Feeds with GitHub Actions and Gists"
-description: "How I set up automated Spotify and GitHub activity feeds for my personal site using GitHub Actions and Gists"
-pubDate: 2025-12-15
-tags: ["github-actions", "automation", "astro"]
+title: Automating Activity Feeds with GitHub Actions and Gists
+description: How I set up automated Spotify and GitHub activity feeds for my personal site using GitHub Actions and Gists
+pubDate: 2025-12-15T00:00:00.000Z
+tags:
+  - github-actions
+  - automation
+  - astro
 syndicate: true
+devtoId: 3442457
 ---
 
 I wanted my personal site to show what I'm currently listening to on Spotify and what I've been coding on GitHub. The challenge: keeping this data fresh without manual updates or expensive API calls on every page load.

--- a/src/content/writing/automating-activity-feeds.md
+++ b/src/content/writing/automating-activity-feeds.md
@@ -3,6 +3,7 @@ title: "Automating Activity Feeds with GitHub Actions and Gists"
 description: "How I set up automated Spotify and GitHub activity feeds for my personal site using GitHub Actions and Gists"
 pubDate: 2025-12-15
 tags: ["github-actions", "automation", "astro"]
+syndicate: true
 ---
 
 I wanted my personal site to show what I'm currently listening to on Spotify and what I've been coding on GitHub. The challenge: keeping this data fresh without manual updates or expensive API calls on every page load.

--- a/src/content/writing/building-an-authentication-service.md
+++ b/src/content/writing/building-an-authentication-service.md
@@ -3,6 +3,7 @@ title: "Extracting Authentication to a Microservice"
 description: "Lessons from extracting authentication and authorisation into a dedicated microservice, including database migration, in-memory testing, and architectural decisions"
 pubDate: 2025-11-07
 tags: ["authentication", "microservices", "architecture", "testing", "database-migration"]
+syndicate: true
 ---
 
 ## The Problem

--- a/src/content/writing/building-an-authentication-service.md
+++ b/src/content/writing/building-an-authentication-service.md
@@ -1,9 +1,15 @@
 ---
-title: "Extracting Authentication to a Microservice"
-description: "Lessons from extracting authentication and authorisation into a dedicated microservice, including database migration, in-memory testing, and architectural decisions"
-pubDate: 2025-11-07
-tags: ["authentication", "microservices", "architecture", "testing", "database-migration"]
+title: Extracting Authentication to a Microservice
+description: Lessons from extracting authentication and authorisation into a dedicated microservice, including database migration, in-memory testing, and architectural decisions
+pubDate: 2025-11-07T00:00:00.000Z
+tags:
+  - authentication
+  - microservices
+  - architecture
+  - testing
+  - database-migration
 syndicate: true
+devtoId: 3442456
 ---
 
 ## The Problem

--- a/src/content/writing/building-swanson-recommendation-system.md
+++ b/src/content/writing/building-swanson-recommendation-system.md
@@ -1,9 +1,17 @@
 ---
 title: "Building Swanson: A RAG-Enhanced Recommendation System for whatisonthe.tv"
-description: "How I built a context-aware recommendation system using Claude, Server-Sent Events, and viewing history to suggest TV shows and films"
-pubDate: 2026-02-07
-tags: ["ai", "python", "fastapi", "svelte", "llm", "streaming", "rag"]
+description: How I built a context-aware recommendation system using Claude, Server-Sent Events, and viewing history to suggest TV shows and films
+pubDate: 2026-02-07T00:00:00.000Z
+tags:
+  - ai
+  - python
+  - fastapi
+  - svelte
+  - llm
+  - streaming
+  - rag
 syndicate: true
+devtoId: 3442458
 ---
 
 > **Background reading:** This article builds on [Building whatisonthe.tv with FastAPI](/projects/building-whatisonthetv/), which covers the core architecture, async patterns, and caching strategies used in the application.

--- a/src/content/writing/building-swanson-recommendation-system.md
+++ b/src/content/writing/building-swanson-recommendation-system.md
@@ -3,6 +3,7 @@ title: "Building Swanson: A RAG-Enhanced Recommendation System for whatisonthe.t
 description: "How I built a context-aware recommendation system using Claude, Server-Sent Events, and viewing history to suggest TV shows and films"
 pubDate: 2026-02-07
 tags: ["ai", "python", "fastapi", "svelte", "llm", "streaming", "rag"]
+syndicate: true
 ---
 
 > **Background reading:** This article builds on [Building whatisonthe.tv with FastAPI](/projects/building-whatisonthetv/), which covers the core architecture, async patterns, and caching strategies used in the application.

--- a/src/content/writing/building-with-astro.md
+++ b/src/content/writing/building-with-astro.md
@@ -1,9 +1,13 @@
 ---
-title: "Building a Personal Site with Astro"
-description: "Why I chose Astro for my personal website and what I learned in the process"
-pubDate: 2025-11-05
-tags: ["astro", "web development", "meta"]
+title: Building a Personal Site with Astro
+description: Why I chose Astro for my personal website and what I learned in the process
+pubDate: 2025-11-05T00:00:00.000Z
+tags:
+  - astro
+  - web development
+  - meta
 syndicate: true
+devtoId: 3442463
 ---
 
 After years of having various iterations of personal websites (and letting them languish), I decided to rebuild from scratch with Astro. Here's why and what I learned.

--- a/src/content/writing/building-with-astro.md
+++ b/src/content/writing/building-with-astro.md
@@ -3,6 +3,7 @@ title: "Building a Personal Site with Astro"
 description: "Why I chose Astro for my personal website and what I learned in the process"
 pubDate: 2025-11-05
 tags: ["astro", "web development", "meta"]
+syndicate: true
 ---
 
 After years of having various iterations of personal websites (and letting them languish), I decided to rebuild from scratch with Astro. Here's why and what I learned.

--- a/src/content/writing/indexatron-local-llm-photo-analysis.md
+++ b/src/content/writing/indexatron-local-llm-photo-analysis.md
@@ -3,6 +3,7 @@ title: "Indexatron: Teaching Local LLMs to See Family Photos"
 description: "An experiment using Ollama with LLaVA and nomic-embed-text to analyse family photos locally - proving that privacy-preserving AI photo analysis actually works"
 pubDate: 2026-02-22
 tags: ["ai", "python", "ollama", "llm", "privacy", "experiment"]
+syndicate: true
 ---
 
 > **Status:** ✅ SUCCESS

--- a/src/content/writing/indexatron-local-llm-photo-analysis.md
+++ b/src/content/writing/indexatron-local-llm-photo-analysis.md
@@ -1,9 +1,16 @@
 ---
 title: "Indexatron: Teaching Local LLMs to See Family Photos"
-description: "An experiment using Ollama with LLaVA and nomic-embed-text to analyse family photos locally - proving that privacy-preserving AI photo analysis actually works"
-pubDate: 2026-02-22
-tags: ["ai", "python", "ollama", "llm", "privacy", "experiment"]
+description: An experiment using Ollama with LLaVA and nomic-embed-text to analyse family photos locally - proving that privacy-preserving AI photo analysis actually works
+pubDate: 2026-02-22T00:00:00.000Z
+tags:
+  - ai
+  - python
+  - ollama
+  - llm
+  - privacy
+  - experiment
 syndicate: true
+devtoId: 3442464
 ---
 
 > **Status:** ✅ SUCCESS

--- a/src/content/writing/maintaining-open-source-in-the-ai-era.md
+++ b/src/content/writing/maintaining-open-source-in-the-ai-era.md
@@ -3,6 +3,7 @@ title: "Maintaining Open Source in the AI Era"
 description: "Reflections on building and maintaining Ruby and Python packages, how AI has changed the process, and why I'm not entirely sure it's for the better"
 pubDate: 2026-03-17
 tags: ["open-source", "ai", "ruby", "python", "developer-tools"]
+syndicate: true
 ---
 
 I've been maintaining a handful of open source packages lately: [mailview](https://pypi.org/project/mailview/), [mailjunky](https://pypi.org/project/mailjunky/) (in both Python and Ruby), and recently dusted off an old Ruby gem called [tvdb_api](https://rubygems.org/gems/tvdb_api/). The experience has been illuminating - not just about package management, but about how AI is changing open source development in ways I'm still processing.

--- a/src/content/writing/maintaining-open-source-in-the-ai-era.md
+++ b/src/content/writing/maintaining-open-source-in-the-ai-era.md
@@ -1,9 +1,15 @@
 ---
-title: "Maintaining Open Source in the AI Era"
-description: "Reflections on building and maintaining Ruby and Python packages, how AI has changed the process, and why I'm not entirely sure it's for the better"
-pubDate: 2026-03-17
-tags: ["open-source", "ai", "ruby", "python", "developer-tools"]
+title: Maintaining Open Source in the AI Era
+description: Reflections on building and maintaining Ruby and Python packages, how AI has changed the process, and why I'm not entirely sure it's for the better
+pubDate: 2026-03-17T00:00:00.000Z
+tags:
+  - open-source
+  - ai
+  - ruby
+  - python
+  - developer-tools
 syndicate: true
+devtoId: 3442474
 ---
 
 I've been maintaining a handful of open source packages lately: [mailview](https://pypi.org/project/mailview/), [mailjunky](https://pypi.org/project/mailjunky/) (in both Python and Ruby), and recently dusted off an old Ruby gem called [tvdb_api](https://rubygems.org/gems/tvdb_api/). The experience has been illuminating - not just about package management, but about how AI is changing open source development in ways I'm still processing.

--- a/src/content/writing/working-with-claude.md
+++ b/src/content/writing/working-with-claude.md
@@ -3,6 +3,7 @@ title: "Working with Claude: A Senior Developer's Honest Take"
 description: "After months of integrating AI into my development workflow, here's what actually works and why planning mode, skills, and tasks have been game changers"
 pubDate: 2026-01-27
 tags: ["ai", "workflow", "developer-tools", "productivity"]
+syndicate: true
 ---
 
 I've been using Claude Code as part of my daily development workflow for several months now. This isn't a breathless endorsement or a dismissive rejection. It's an honest assessment from someone who's been writing software professionally for over two decades.

--- a/src/content/writing/working-with-claude.md
+++ b/src/content/writing/working-with-claude.md
@@ -1,9 +1,14 @@
 ---
 title: "Working with Claude: A Senior Developer's Honest Take"
-description: "After months of integrating AI into my development workflow, here's what actually works and why planning mode, skills, and tasks have been game changers"
-pubDate: 2026-01-27
-tags: ["ai", "workflow", "developer-tools", "productivity"]
+description: After months of integrating AI into my development workflow, here's what actually works and why planning mode, skills, and tasks have been game changers
+pubDate: 2026-01-27T00:00:00.000Z
+tags:
+  - ai
+  - workflow
+  - developer-tools
+  - productivity
 syndicate: true
+devtoId: 3442465
 ---
 
 I've been using Claude Code as part of my daily development workflow for several months now. This isn't a breathless endorsement or a dismissive rejection. It's an honest assessment from someone who's been writing software professionally for over two decades.


### PR DESCRIPTION
## Summary

- Add automated syndication pipeline that publishes content to dev.to via their API
- Preserve canonical URLs back to swm.cc for SEO
- Store dev.to article IDs in frontmatter for future updates
- All 16 existing posts synced and tested

## Changes

- Add `syndicate` and `devtoId` fields to writing/notes schemas
- Create `scripts/syndicate.mjs` with rate limiting and tag sanitization
- Add GitHub Action triggered on content changes to main
- Add `make local.syndicate` target for local testing
- Enable syndication for all existing posts

## Setup Required

Add `DEVTO_API_KEY` to repository secrets before merging.

## Test plan

- [x] Tested locally with `make local.syndicate`
- [x] All 16 posts successfully synced to dev.to
- [x] Canonical URLs correctly point to swm.cc
- [x] Rate limiting handles dev.to API limits

Closes #92

🤖 Generated with [Claude Code](https://claude.ai/code)