### PR TITLE
🔒 Remove hardcoded Spotify credentials from update script

### DIFF
--- a/scripts/update_spotify.py
+++ b/scripts/update_spotify.py
@@ -9,13 +9,23 @@ import requests
 
 ROOT_DIR = Path(__file__).parent.parent
 
-# Credentials from env vars (GitHub Actions) or fallback to hardcoded (local dev)
-CLIENT_ID = os.environ.get("SPOTIFY_CLIENT_ID", "af253baf8c664d648e4e01308bd2c052")
-CLIENT_SECRET = os.environ.get("SPOTIFY_CLIENT_SECRET", "0d06f3babe96490bb720945171a78183")
-REFRESH_TOKEN = os.environ.get(
-    "SPOTIFY_REFRESH_TOKEN",
-    "AQBVmhhsO-dlNZdhQm-thLmbT7MQuxPHiCqWzJOWMJPgp0jcsMsv-ZNhDUSXejxlwmcZv7ceOXw-gFinhNuhEqv8ljgnShCAiWu3wOC1WeEZCNcT690f5DG8yHwyCGLuU7U"
-)
+# Credentials must be provided via environment variables — never hardcode them.
+CLIENT_ID = os.environ.get("SPOTIFY_CLIENT_ID")
+CLIENT_SECRET = os.environ.get("SPOTIFY_CLIENT_SECRET")
+REFRESH_TOKEN = os.environ.get("SPOTIFY_REFRESH_TOKEN")
+
+missing = [
+    name
+    for name, value in [
+        ("SPOTIFY_CLIENT_ID", CLIENT_ID),
+        ("SPOTIFY_CLIENT_SECRET", CLIENT_SECRET),
+        ("SPOTIFY_REFRESH_TOKEN", REFRESH_TOKEN),
+    ]
+    if not value
+]
+if missing:
+    print(f"Error: missing required environment variable(s): {', '.join(missing)}")
+    exit(1)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--output", "-o", help="Output file path")


### PR DESCRIPTION
## Summary

Fixes the code side of #96 (Spotify integration broken: refresh token revoked).

- `scripts/update_spotify.py` had the Spotify client ID, client secret, and refresh token hardcoded as `os.environ.get()` fallbacks in this **public** repo. The leaked refresh token was revoked by Spotify, which is why the `Update Spotify Activity` workflow has been failing.
- Credentials are now read from environment variables only. If any of `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, or `SPOTIFY_REFRESH_TOKEN` are missing, the script exits with an error naming the missing variable(s).

## Verification

- Repo-wide grep confirms the leaked values appear nowhere else in the working tree (docs, README, workflows, blog posts are clean).
- `.github/workflows/update-spotify.yml` already passes the three secrets as env vars correctly — no workflow change needed.
- ✅ `ruff check scripts/` — clean
- ✅ `npm test` (Playwright) — 16/16 passed

## Remaining manual steps (not in this PR)

The old client secret and refresh token are in public git history and must be treated as burned: rotate the client secret in the Spotify developer dashboard, mint a fresh refresh token, and update the `SPOTIFY_*` repo secrets. Details in #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)